### PR TITLE
added okteto and tags

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,106 @@
+.git
+# Byte-compiled / optimized / DLL files
+__pycache__
+*.py[cod]
+*$py.class
+
+node_modules/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build
+develop-eggs
+dist
+downloads
+eggs
+.eggs
+lib
+lib64
+parts
+sdist
+var
+wheels
+pip-wheel-metadata
+share/python-wheels
+*.egg-info
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build
+
+# PyBuilder
+target
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env
+venv
+ENV
+env.bak
+venv.bak
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mypy
+.mypy_cache
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre
+
+bin/manager
+bin/activator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+from statsd/statsd:latest
+
+COPY . ../statsd-postgres-backend
+
+RUN cd .. \
+    && cd statsd-postgres-backend \
+    && npm install pg@^8
+
+ADD statsdconfig.js config.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build:
+	okteto build -f ./Dockerfile -t okteto.dev/beam-statsd:latest
+
+start:
+	okteto up -f ./okteto.yml

--- a/okteto.yml
+++ b/okteto.yml
@@ -1,0 +1,7 @@
+name: beam-statsd
+image: okteto.dev/beam-statsd:latest
+command: ["node", "stats.js", "config.js"]
+sync:
+  - .:/workspace
+volumes:
+  - /root/.cache/pip

--- a/okteto.yml
+++ b/okteto.yml
@@ -2,6 +2,6 @@ name: beam-statsd
 image: okteto.dev/beam-statsd:latest
 command: ["node", "stats.js", "config.js"]
 sync:
-  - .:/workspace
+  - .:../statsd-postgres-backend
 volumes:
   - /root/.cache/pip

--- a/statsdPostgresBackend.js
+++ b/statsdPostgresBackend.js
@@ -162,12 +162,15 @@ module.exports = (function () {
         pgPool = await initConnectionPool(config);
       }
 
+      console.log(events);
+
       events.on("flush", function (timestamp, statsdMetrics) {
         let metrics = extractor(
           timestamp,
           statsdMetrics.counters,
           STATSD_TYPES.count
         );
+
         metrics = metrics.concat(
           extractor(timestamp, statsdMetrics.gauges, STATSD_TYPES.gauges)
         );

--- a/statsdconfig.js
+++ b/statsdconfig.js
@@ -1,0 +1,11 @@
+{
+  pghost: `postgres-postgresql.${process.env.OKTETO_NAMESPACE}.svc.cluster.local`,
+  pguser: "postgres",
+  pgpass: "password",
+  pgdb: "postgres",
+  pgport: 5432,
+  pginit: false,
+  port: 8125,
+  backends: [ "../statsd-postgres-backend" ],
+  deleteGauges: true,
+}


### PR DESCRIPTION
statsd strings are in the form of 
`<topic>.<category>.<subcategory>.<identity>.<metric>` with a string value (this string value is serialized depending on the use case (e.g. `beam.imgfs.cacher.<image-tag>.size` with value 800000. we can serialize this as bytes)

the way that tags work is we append `;` separate `key=value` after the `<metrics>`. 
e.g `beam.imgfs.cacher.<image-tag>.size;node_name=<name>;pod_name=<name>`

This is how datadog and graphite does it (datadog uses a different tag though and i think graphite uses `:`)